### PR TITLE
Myls5

### DIFF
--- a/05.ls/myls.rb
+++ b/05.ls/myls.rb
@@ -59,11 +59,15 @@ def hardlink
 end
 
 def orner_name
-  file_stats.map { |file_element| Etc.getpwuid(file_element.uid).name }
+  orner = file_stats.map { |file_element| Etc.getpwuid(file_element.uid).name }
+  longest_orner = orner.map(&:size).max
+  orner.map { |o| "#{o.ljust(longest_orner)}" }
 end
 
 def group_name
-  file_stats.map { |file_element| " #{Etc.getgrgid(file_element.gid).name}" }
+  group = file_stats.map { |file_element| " #{Etc.getgrgid(file_element.gid).name}" }
+  longest_group = group.map(&:size).max
+  group.map { |g| "#{g.ljust(longest_group)}" }
 end
 
 def filesize


### PR DESCRIPTION
## プラクティス名
lsコマンドを作る5

## コメント
### 終了条件について
>-a -r -l オプションを全て使用できるlsコマンドを作って提出する。
上記については前回のlsコマンド4のコードで満たしているため、変更しておりません。

### 修正点
終了条件とは別件ですが、以下修正しております。
- orner_nameとgroup_nameの表示を揃えるための記述を追加
  - それぞれ、出力結果のうち**最大文字数に対して左寄せ**で表示できるようにしました。